### PR TITLE
Fixed two typos

### DIFF
--- a/probability_theory/probability_theory.Rmd
+++ b/probability_theory/probability_theory.Rmd
@@ -812,8 +812,8 @@ the expectation of a simple function will always be finite provided that each of
 the coefficients $a_{n}$ are themselves finite.
 
 We can then use simple functions to approximate an everywhere-positive function,
-$g : X \rightarrow \mathbb{R}^{+}$.  A simple function with only a few terms
-defined over only a few sets will yield a poor approximation to $g$, but as we
+$f : X \rightarrow \mathbb{R}^{+}$.  A simple function with only a few terms
+defined over only a few sets will yield a poor approximation to $f$, but as we
 consider more terms and more sets we can build an increasingly accurate
 approximation.  In particular, because of countable additivity we can always 
 construct a simple function that approximates $f$ with arbitrary accuracy while
@@ -841,7 +841,7 @@ $$
 while in the neighborhoods where $f$ is entirely negative we apply the above
 procedure on the negation of $f$ to define
 $$
-\mathbb{E}_{\pi} [ -f \cdot \mathbb{I}_{A^{+}_{n}}].
+\mathbb{E}_{\pi} [ -f \cdot \mathbb{I}_{A^{-}_{n}}].
 $$
 Those regions where $f$ vanishes yield zero expectation values and can be
 ignored.  We then define the expectation value of an arbitrary function $f$ as


### PR DESCRIPTION
I think I found two typos: 

1) In the paragraph starting at line 814, it seems that you first refer to a function as g, then change it to f. Since the notation keeps referring to f, I changed the g for f in lines 815 and 816. 

2) At line 844, the formula refers to entirely negative regions, but the indicator function evaluated at entirely positive ones. I changed the sign.